### PR TITLE
Remove the use of btoa

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Disadvantages:
 
 * Unlike `PIXI.Text`, HTMLText rendering will vary slightly between platforms and browsers. HTMLText uses SVG/DOM to render text and not Context2D's fillText like `PIXI.Text`.
 * Performance and memory usage is on-par with `PIXI.Text` (that is to say, slow and heavy)
-* Only works with browsers that support [`btoa`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/btoa) and [`<foreignObject>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/foreignObject), i.e., no Internet Explorer support
+* Only works with browsers that support [`<foreignObject>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/foreignObject), i.e., no Internet Explorer support.
 
 ## Install
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,11 +24,6 @@ export class HTMLText extends Sprite
      */
     constructor(text = '', style = {}, canvas)
     {
-        if (typeof btoa === 'undefined')
-        {
-            throw new Error('Your browser doesn\'t support base64 conversions.');
-        }
-
         canvas = canvas || document.createElement('canvas');
 
         canvas.width = 3;
@@ -170,7 +165,7 @@ export class HTMLText extends Sprite
             const image = this._image;
 
             this._loading = true;
-            image.src = `data:image/svg+xml;base64,${btoa(svg)}`;
+            image.src = `data:image/svg+xml,${encodeURIComponent(svg)}`;
             image.onload = () =>
             {
                 context.drawImage(


### PR DESCRIPTION
The use of `btoa` is unnecessary, removing this internal dependency.