### PR TITLE
Add missing members to the TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,9 @@ declare namespace PIXI {
         readonly context:CanvasRenderingContext2D;
         text:string;
         style:PIXI.TextStyle;
+        resolution: number;
+        width: number;
+        height: number;
         updateText(respectDirty?:boolean): void;
     }
 }


### PR DESCRIPTION
Added three members that were missing from the TypeScript typings, and are documented here: [documentation](https://pixijs.io/html-text/docs/PIXI.HTMLText.html).