### PR TITLE
fix: make text style type `Partial`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ export class HTMLText extends Sprite {
     readonly canvas:HTMLCanvasElement;
     readonly context:CanvasRenderingContext2D;
     text:string;
-    style:Partial<TextStyle>;
+    style:TextStyle;
     resolution: number;
     updateText(respectDirty?:boolean): void;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,11 +2,11 @@ import { Sprite } from '@pixi/sprite';
 import { TextStyle } from '@pixi/text';
 
 export class HTMLText extends Sprite {
-    constructor(text?:string, style?:TextStyle, canvas?:HTMLCanvasElement);
+    constructor(text?:string, style?:Partial<TextStyle>, canvas?:HTMLCanvasElement);
     readonly canvas:HTMLCanvasElement;
     readonly context:CanvasRenderingContext2D;
     text:string;
-    style:TextStyle;
+    style:Partial<TextStyle>;
     resolution: number;
     updateText(respectDirty?:boolean): void;
 }


### PR DESCRIPTION
all of the text style properties are optional based on the implementation, but the current type definition requires them all to be defined