### PR TITLE
Added support of css styles and support Pseudo-classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 docs
 .DS_Store
+.history

--- a/demo/index.html
+++ b/demo/index.html
@@ -52,9 +52,17 @@
         dropShadowColor: '#cccccc',
       });
 
-      const text = 'Lorem ipsum dolor sit amet, &#x1F680; <b>consectetur adipiscing elit</b>. Phasellus porta nisi est, vitae <i>sagittis ex gravida ac</i>. Sed vitae malesuada neque.';
+      const text = '<p>Lorem <a href="#">ipsum</a> dolor sit amet, &#x1F680; <b>consectetur adipiscing elit</b>.</p> <p>Phasellus porta nisi est, vitae <i>sagittis ex gravida ac</i>. Sed vitae malesuada neque.</p>';
+      const cssStyle = {
+        '&': 'position: relative; line-height: 48px; height: 96px; overflow: hidden;',
+        // Multi-line text overflow ellipsis through pseudo-elements
+        '&::after': 'content: "..."; position: absolute; bottom: 0;right: 0; background: #999999;',
+        'p': 'margin-bottom: 0;margin-top: 30px;',
+        'p:nth-of-type(1)': 'margin: 0;',
+        'a': 'color: aquamarine;'
+      }
 
-      const text2 = new PIXI.HTMLText(text, style);
+      const text2 = new PIXI.HTMLText(text, style, null, cssStyle);
       text2.texture.baseTexture.on('update', () => app.render());
       text2.y = 20;
       text2.x = 20;

--- a/demo/index.html
+++ b/demo/index.html
@@ -54,12 +54,30 @@
 
       const text = '<p>Lorem <a href="#">ipsum</a> dolor sit amet, &#x1F680; <b>consectetur adipiscing elit</b>.</p> <p>Phasellus porta nisi est, vitae <i>sagittis ex gravida ac</i>. Sed vitae malesuada neque.</p>';
       const cssStyle = {
-        '&': 'position: relative; line-height: 48px; height: 96px; overflow: hidden;',
+        '&': {
+          position: 'relative',
+          'line-height': '48px',
+          height: '96px',
+          overflow: 'hidden',
+        },
         // Multi-line text overflow ellipsis through pseudo-elements
-        '&::after': 'content: "..."; position: absolute; bottom: 0;right: 0; background: #999999;',
-        'p': 'margin-bottom: 0;margin-top: 30px;',
-        'p:nth-of-type(1)': 'margin: 0;',
-        'a': 'color: aquamarine;'
+        '&::after': {
+          content: '"..."',
+          position: 'absolute',
+          bottom: 0,
+          right: 0,
+          background: '#999999',
+        },
+        'p': {
+          'margin-bottom': 0,
+          'margin-top': '30px'
+        },
+        'p:nth-of-type(1)': {
+          margin: 0,
+        },
+        'a': {
+          color: 'aquamarine'
+        }
       }
 
       const text2 = new PIXI.HTMLText(text, style, null, cssStyle);
@@ -75,6 +93,8 @@
         .drawShape(text2.getBounds());
 
       app.stage.addChild(rect, text2);
+      // 'ipsum' will show white background, aquamarine color text
+      text2.cssStyle['a'].background = '#fff';
     </script>
   </body>
 </html>

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ import { Sprite } from '@pixi/sprite';
 import { TextStyle } from '@pixi/text';
 
 export class HTMLText extends Sprite {
-    constructor(text?:string, style?:PIXI.TextStyle, canvas?:HTMLCanvasElement, cssStyle?: Record<string, Record<string, boolean>>);
+    constructor(text?:string, style?:PIXI.TextStyle, canvas?:HTMLCanvasElement, cssStyle?: Record<string, Record<string, unknown>>);
     readonly canvas:HTMLCanvasElement;
     readonly context:CanvasRenderingContext2D;
     text:string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ export class HTMLText extends Sprite {
     readonly context:CanvasRenderingContext2D;
     text:string;
     style:TextStyle;
-    cssStyle:Record<string, string>;
+    cssStyle:Record<string, Record<string, unknown>>;
     resolution: number;
     updateText(respectDirty?:boolean): void;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ import { Sprite } from '@pixi/sprite';
 import { TextStyle } from '@pixi/text';
 
 export class HTMLText extends Sprite {
-    constructor(text?:string, style?:PIXI.TextStyle, canvas?:HTMLCanvasElement, cssStyle?: Record<string, string>);
+    constructor(text?:string, style?:PIXI.TextStyle, canvas?:HTMLCanvasElement, cssStyle?: Record<string, Record<string, boolean>>);
     readonly canvas:HTMLCanvasElement;
     readonly context:CanvasRenderingContext2D;
     text:string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,11 +2,12 @@ import { Sprite } from '@pixi/sprite';
 import { TextStyle } from '@pixi/text';
 
 export class HTMLText extends Sprite {
-    constructor(text?:string, style?:TextStyle, canvas?:HTMLCanvasElement);
+    constructor(text?:string, style?:PIXI.TextStyle, canvas?:HTMLCanvasElement, cssStyle?: Record<string, string>);
     readonly canvas:HTMLCanvasElement;
     readonly context:CanvasRenderingContext2D;
     text:string;
     style:TextStyle;
+    cssStyle:Record<string, string>;
     resolution: number;
     updateText(respectDirty?:boolean): void;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -21,8 +21,10 @@ export class HTMLText extends Sprite
      * @param {PIXI.TextStyle} [style] - Style settings, not all TextStyle options are supported.
      * @param {HTMLCanvasElement} [canvas] - Optional canvas to use for rendering.
      *.       if undefined, will generate it's own canvas using createElement.
+     * @param {object<string, string>} [cssStyle] - CSS Style settings for HTML elements in text
+     *        Where key is selector, value is styles
      */
-    constructor(text = '', style = {}, canvas)
+    constructor(text = '', style = {}, canvas, cssStyle = {})
     {
         canvas = canvas || document.createElement('canvas');
 
@@ -45,9 +47,11 @@ export class HTMLText extends Sprite
         this._autoResolution = true;
         this._text = null;
         this._style = null;
+        this._cssStyle = null;
         this._loading = false;
         this.text = text;
         this.style = style;
+        this.cssStyle = cssStyle;
         this.localStyleID = -1;
     }
 
@@ -140,10 +144,15 @@ export class HTMLText extends Sprite
         const svg = `
             <svg xmlns="http://www.w3.org/2000/svg" width="2048" height="2048">
                 <foreignObject width="100%" height="100%">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="${css}">${this._text}</div>
+                    <div xmlns="http://www.w3.org/1999/xhtml" class="pixi-html_text" style="${css}">
+                    ${this._text}
+                        <style>
+                            ${this.stringCssStyle}
+                        </style>
+                    </div>
                 </foreignObject>
             </svg>
-       `;
+        `;
 
         // Used to measure to D
         const template = this._parser.parseFromString(svg, 'text/xml');
@@ -181,7 +190,23 @@ export class HTMLText extends Sprite
             this.updateTexture();
         }
     }
-
+    /**
+     * Convert cssStyle object to css string, key is selector, value is css style
+     * When the key is `&`, it means to select the `.pixi-html_text` element
+     * Supports pseudo-element selectors, such as `&::after`
+     */
+    get stringCssStyle()
+    {
+        let css = '';
+        for (let k in this._cssStyle)
+        {
+            const v = this._cssStyle[k];
+            // When the key is `&`, it means to select the `.pixi-html_text` element
+            if (/^&/.test(k)) k = k.replace('&', '');
+            css += `.pixi-html_text ${k} {${v}}`;
+        }
+        return css;
+    }
     /**
      * Update the texture resource.
      * @private
@@ -303,6 +328,7 @@ export class HTMLText extends Sprite
         this.canvas.width = this.canvas.height = 0; // Safari hack
         this.canvas = null;
         this._style = null;
+        this._cssStyle = null;
         this._parser = null;
         this._image.onload = null;
         this._image.src = '';
@@ -374,6 +400,21 @@ export class HTMLText extends Sprite
         }
 
         this.localStyleID = -1;
+        this.dirty = true;
+    }
+
+    /**
+     * The CSS style to render with text.
+     * @member {string}
+     */
+    get cssStyle()
+    {
+        return this._cssStyle;
+    }
+
+    set cssStyle(style) // eslint-disable-line require-jsdoc
+    {
+        this._cssStyle = style || {};
         this.dirty = true;
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -202,9 +202,11 @@ export class HTMLText extends Sprite
         {
             let cssStr = '';
 
-            for (const key in cssObject) {
+            for (const key in cssObject)
+            {
                 // eslint-disable-next-line no-prototype-builtins
-                if (cssObject.hasOwnProperty(key)) {
+                if (cssObject.hasOwnProperty(key))
+                {
                     cssStr += `${key}:${cssObject[key]};`;
                 }
             }
@@ -218,7 +220,7 @@ export class HTMLText extends Sprite
             const cssObj = this._cssStyle[selector];
 
             // When the key is `&`, it means to select the `.pixi-html_text` element
-            if (/^&/.test(selector)) selector = selector.replace('&', '');
+            if ((/^&/).test(selector)) selector = selector.replace('&', '');
             css += `.pixi-html_text ${selector} {${formatCss(cssObj)}}`;
         }
 
@@ -422,7 +424,7 @@ export class HTMLText extends Sprite
 
     /**
      * The CSS style to render with text.
-     * @member {string}
+     * @member {object}
      */
     get cssStyle()
     {

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ export class HTMLText extends Sprite
      * @param {PIXI.TextStyle} [style] - Style settings, not all TextStyle options are supported.
      * @param {HTMLCanvasElement} [canvas] - Optional canvas to use for rendering.
      *.       if undefined, will generate it's own canvas using createElement.
-     * @param {object<string, string>} [cssStyle] - CSS Style settings for HTML elements in text
+     * @param {object<string, object<string, unknown>>} [cssStyle] - CSS Style settings for HTML elements in text
      *        Where key is selector, value is styles
      */
     constructor(text = '', style = {}, canvas, cssStyle = {})
@@ -198,13 +198,30 @@ export class HTMLText extends Sprite
     get stringCssStyle()
     {
         let css = '';
-        for (let k in this._cssStyle)
+        const formatCss = (cssObject) =>
         {
-            const v = this._cssStyle[k];
+            let cssStr = '';
+
+            for (const key in cssObject) {
+                // eslint-disable-next-line no-prototype-builtins
+                if (cssObject.hasOwnProperty(key)) {
+                    cssStr += `${key}:${cssObject[key]};`;
+                }
+            }
+
+            return cssStr;
+        };
+
+        for (const k in this._cssStyle)
+        {
+            let selector = k;
+            const cssObj = this._cssStyle[selector];
+
             // When the key is `&`, it means to select the `.pixi-html_text` element
-            if (/^&/.test(k)) k = k.replace('&', '');
-            css += `.pixi-html_text ${k} {${v}}`;
+            if (/^&/.test(selector)) selector = selector.replace('&', '');
+            css += `.pixi-html_text ${selector} {${formatCss(cssObj)}}`;
         }
+
         return css;
     }
     /**


### PR DESCRIPTION
```js
      const text = '<p>Lorem <a href="#">ipsum</a> dolor sit amet, &#x1F680; <b>consectetur adipiscing elit</b>.</p> <p>Phasellus porta nisi est, vitae <i>sagittis ex gravida ac</i>. Sed vitae malesuada neque.</p>';
      const cssStyle = {
        '&': {
          position: 'relative',
          'line-height': '48px',
          height: '96px',
          overflow: 'hidden',
        },
        // Multi-line text overflow ellipsis through pseudo-elements
        '&::after': {
          content: '"..."',
          position: 'absolute',
          bottom: 0,
          right: 0,
          background: '#999999',
        },
        'p': {
          'margin-bottom': 0,
          'margin-top': '30px'
        },
        'p:nth-of-type(1)': {
          margin: 0,
        },
        'a': {
          color: 'aquamarine'
        }
      };

      const text2 = new PIXI.HTMLText(text, style, null, cssStyle);
      text2.cssStyle['a'].background = '#fff';
```


![image](https://user-images.githubusercontent.com/10083758/160993074-8ac47c06-1cad-4a36-9b4f-eb8d87bce097.png)



fix: #7 