### PR TITLE
Add measureText (non-rendering method)

### DIFF
--- a/src/HTMLText.ts
+++ b/src/HTMLText.ts
@@ -1,5 +1,5 @@
 import { Sprite } from '@pixi/sprite';
-import { Texture, Rectangle, settings, utils, ICanvas, ICanvasRenderingContext2D } from '@pixi/core';
+import { Texture, Rectangle, settings, utils, ICanvas, ICanvasRenderingContext2D, ISize } from '@pixi/core';
 import { TextStyle } from '@pixi/text';
 import { HTMLTextStyle } from './HTMLTextStyle';
 
@@ -16,7 +16,13 @@ import type { IDestroyOptions } from '@pixi/display';
  */
 export class HTMLText extends Sprite
 {
-    /** Default opens when destroying */
+    /**
+     * Default opens when destroying.
+     * @type {PIXI.IDestroyOptions}
+     * @property {boolean} texture=true - Whether to destroy the texture.
+     * @property {boolean} children=false - Whether to destroy the children.
+     * @property {boolean} baseTexture=true - Whether to destroy the base texture.
+     */
     public static defaultDestroyOptions: IDestroyOptions = {
         texture: true,
         children: false,
@@ -125,6 +131,41 @@ export class HTMLText extends Sprite
     }
 
     /**
+     * Calculate the size of the output text without actually drawing it.
+     * This includes the `padding` in the `style` object.
+     * This can be used as a fast-pass to do things like text-fitting.
+     * @param {string} text - The text to measure.
+     */
+    measureText(text: string): ISize
+    {
+        const { style, resolution } = this;
+        const oldText = this._text as string;
+
+        Object.assign(this._domElement, {
+            innerHTML: text,
+            style: style.toCSS(resolution),
+        });
+        this._styleElement.textContent = style.toGlobalCSS();
+
+        // Measure the contents using the shadow DOM
+        const contentBounds = this._domElement.getBoundingClientRect();
+
+        const contentWidth = Math.min(this.maxWidth, Math.ceil(contentBounds.width));
+        const contentHeight = Math.min(this.maxHeight, Math.ceil(contentBounds.height));
+
+        this._svgRoot.setAttribute('width', contentWidth.toString());
+        this._svgRoot.setAttribute('height', contentHeight.toString());
+
+        // Undo the changes to the DOM element
+        Object.assign(this._domElement, { innerHTML: oldText });
+
+        return {
+            width: contentWidth + (style.padding * 2),
+            height: contentHeight + (style.padding * 2),
+        };
+    }
+
+    /**
      * Manually refresh the text.
      * @public
      * @param {boolean} respectDirty - Whether to abort updating the
@@ -132,7 +173,7 @@ export class HTMLText extends Sprite
      */
     updateText(respectDirty = true): void
     {
-        const { style, resolution, canvas, context } = this;
+        const { style, canvas, context } = this;
 
         // check if style has changed..
         if (this.localStyleID !== style.styleID)
@@ -146,23 +187,12 @@ export class HTMLText extends Sprite
             return;
         }
 
-        Object.assign(this._domElement, {
-            innerHTML: this._text,
-            style: style.toCSS(resolution),
-        });
-        this._styleElement.textContent = style.toGlobalCSS();
+        const { width, height } = this.measureText(this._text as string);
 
-        // Measure the contents using the shadow DOM
-        const contentBounds = this._domElement.getBoundingClientRect();
-
-        const width = Math.min(this.maxWidth, Math.ceil(contentBounds.width));
-        const height = Math.min(this.maxHeight, Math.ceil(contentBounds.height));
-
-        this._svgRoot.setAttribute('width', width.toString());
-        this._svgRoot.setAttribute('height', height.toString());
-
-        canvas.width = Math.ceil((Math.max(1, width) + (style.padding * 2)));
-        canvas.height = Math.ceil((Math.max(1, height) + (style.padding * 2)));
+        // Make sure canvas is at least 1x1 so it drawable
+        // for sub-pixel sizes, round up to avoid clipping
+        canvas.width = Math.ceil((Math.max(1, width)));
+        canvas.height = Math.ceil((Math.max(1, height)));
 
         if (!this._loading)
         {

--- a/test/HTMLText.test.ts
+++ b/test/HTMLText.test.ts
@@ -1,4 +1,5 @@
 import { HTMLText } from '../src/HTMLText';
+import { HTMLTextStyle } from '../src/HTMLTextStyle';
 
 describe('HTMLText', () =>
 {
@@ -46,10 +47,22 @@ describe('HTMLText', () =>
 
     describe('measureText', () =>
     {
+        it('should measure default text', () =>
+        {
+            const text = new HTMLText('Hello world!');
+            const size = text.measureText();
+
+            expect(size).toBeTruthy();
+            expect(size.width).toBeGreaterThan(0);
+            expect(size.height).toBeGreaterThan(0);
+
+            text.destroy();
+        });
+
         it('should measure empty text to be drawable', () =>
         {
             const text = new HTMLText();
-            const size = text.measureText('');
+            const size = text.measureText({ text: '' });
 
             expect(size).toBeTruthy();
             expect(size.width).toBe(0);
@@ -58,15 +71,56 @@ describe('HTMLText', () =>
             text.destroy();
         });
 
-        it('should measure text', () =>
+        it('should measure override text', () =>
         {
             const text = new HTMLText();
-            const size = text.measureText('Hello world!');
+            const size = text.measureText({ text: 'Hello world!' });
 
             expect(size).toBeTruthy();
             expect(size.width).toBeGreaterThan(0);
             expect(size.height).toBeGreaterThan(0);
 
+            text.destroy();
+        });
+
+        it('should measure with resolution', () =>
+        {
+            const text = new HTMLText('Hello world!');
+            const size = text.measureText();
+            const size2 = text.measureText({ resolution: 2 });
+
+            expect(Math.abs((size2.width / 2) - size.width)).toBeLessThanOrEqual(1);
+            expect(Math.abs((size2.height / 2) - size.height)).toBeLessThanOrEqual(1);
+            text.destroy();
+        });
+
+        it('should apply override style', () =>
+        {
+            const text = new HTMLText('Hello world!', {
+                fontSize: 12,
+            });
+            const style = new HTMLTextStyle({
+                fontSize: 24,
+            });
+            const size = text.measureText();
+            const size2 = text.measureText({ style });
+
+            expect(Math.abs((size2.width / 2) - size.width)).toBeLessThanOrEqual(1);
+            expect(Math.abs((size2.height / 2) - size.height)).toBeLessThanOrEqual(1);
+            text.destroy();
+        });
+
+        it('should apply override style without touching styleID', () =>
+        {
+            const text = new HTMLText('Hello world!');
+            const styleId = text.style.styleID;
+            const style = new HTMLTextStyle();
+            const style2Id = style.styleID;
+
+            text.measureText();
+            text.measureText({ style });
+            expect(styleId).toBe(text.style.styleID);
+            expect(style2Id).toBe(style.styleID);
             text.destroy();
         });
     });

--- a/test/HTMLText.test.ts
+++ b/test/HTMLText.test.ts
@@ -43,4 +43,31 @@ describe('HTMLText', () =>
 
         expect(document.querySelector(query)).toBeFalsy();
     });
+
+    describe('measureText', () =>
+    {
+        it('should measure empty text to be drawable', () =>
+        {
+            const text = new HTMLText();
+            const size = text.measureText('');
+
+            expect(size).toBeTruthy();
+            expect(size.width).toBe(0);
+            expect(size.height).toBe(0);
+
+            text.destroy();
+        });
+
+        it('should measure text', () =>
+        {
+            const text = new HTMLText();
+            const size = text.measureText('Hello world!');
+
+            expect(size).toBeTruthy();
+            expect(size.width).toBeGreaterThan(0);
+            expect(size.height).toBeGreaterThan(0);
+
+            text.destroy();
+        });
+    });
 });


### PR DESCRIPTION
Closes #4 

### Adds

* New `measureText` method which can be used similar to PixiJS' `TextMetrics.measureText` method. This returns a width and height of the bounds of your text. This method doesn't impact PixiJS rendering so it is therefore faster when attempting to do things like fit text. By default, it uses the built in text, style and resolution, but these things can be overridden.

#### With Text Override 

```js
const text = new HTMLText('Hello world!');
const { width, height } = text.measureText();
```

#### With Text Override 

```js
const text = new HTMLText();
const { width, height } = text.measureText({ text: 'Hello world!' });
```

#### With Style Override 

```js
const text = new HTMLText();
const style = new HTMLTextStyle({
  fontSize: 12,
});
const { width, height } = text.measureText({ style });
```

#### With Resolution Override 

```js
const text = new HTMLText();
const { width, height } = text.measureText({ resolution: 2 });
```