### PR TITLE
Workaround for Safari font image load bug

### DIFF
--- a/src/HTMLText.ts
+++ b/src/HTMLText.ts
@@ -218,14 +218,7 @@ export class HTMLText extends Sprite
 
                 image.onload = async () =>
                 {
-                    // Safari has a known bug where embedded fonts are not available
-                    // immediately after the image loads, to compensate we wait an
-                    // arbitrary amount of time
-                    // @see https://bugs.webkit.org/show_bug.cgi?id=219770
-                    if (style.isSafari && style.numFonts > 0)
-                    {
-                        await new Promise((resolve) => setTimeout(resolve, 100));
-                    }
+                    await style.onBeforeDraw();
                     context.clearRect(0, 0, canvas.width, canvas.height);
                     context.drawImage(
                         image,

--- a/src/HTMLTextStyle.ts
+++ b/src/HTMLTextStyle.ts
@@ -351,8 +351,17 @@ class HTMLTextStyle extends TextStyle
         Object.assign(this, HTMLTextStyle.defaultOptions);
     }
 
-    /** Proving that Safari is the new IE */
-    private get isSafari(): boolean
+    /** @ignore */
+    public get numFonts(): number
+    {
+        return this._fonts.length;
+    }
+
+    /**
+     * Proving that Safari is the new IE
+     * @ignore
+     */
+    public get isSafari(): boolean
     {
         const { userAgent } = settings.ADAPTER.getNavigator();
 

--- a/src/HTMLTextStyle.ts
+++ b/src/HTMLTextStyle.ts
@@ -373,7 +373,7 @@ class HTMLTextStyle extends TextStyle
         // arbitrary amount of time
         // @see https://bugs.webkit.org/show_bug.cgi?id=219770
         if (this.isSafari && this._fonts.length > 0 && prevFontsDirty)
-        {            
+        {
             return new Promise<void>((resolve) => setTimeout(resolve, 100));
         }
 


### PR DESCRIPTION
Safari has a rendering bug with fonts aren't finishing loading fonts on `image.onload` until the browser caches. This adds a small rendering tax for Safari after fonts are added.

See: https://bugs.webkit.org/show_bug.cgi?id=219770